### PR TITLE
Keep min count of PDCs instead of none

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ En complément du regroupement par station, le retraitement suivant effectue div
 * vérifications diverses de cohérence entre les informations des points de recharge et de la station
 * etc
 
+Ces opérations de regroupement et vérifications peuvent révéler des incohérences dans les données. Dans ce cas le champ de sortie est laissé vide. Des champs supplémentaires peuvent être ajouté dans certains cas :
+* `nbre_pdc_unsure` : ce champ est ajouté lors du regroupement lorsque le `nbr_pdc` déclaré pour une station ne correspond pas aux nombres de PDCs effectivement trouvés (exemple `nbr_pdc = 2` et 4 PDCs avec le même station_id -> dans ce cas, la sortie contiendra `nbr_pdc = 0` et `nbr_pdc_unsure = 2`)
+
 Voici les fichiers de sortie du retraitement :
 
 * la liste des stations https://raw.githubusercontent.com/Jungle-Bus/ref-EU-EVSE/gh-pages/opendata_stations.csv

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ En complément du regroupement par station, le retraitement suivant effectue div
 * etc
 
 Ces opérations de regroupement et vérifications peuvent révéler des incohérences dans les données. Dans ce cas le champ de sortie est laissé vide. Des champs supplémentaires peuvent être ajouté dans certains cas :
-* `nbre_pdc_unsure` : ce champ est ajouté lors du regroupement lorsque le `nbr_pdc` déclaré pour une station ne correspond pas aux nombres de PDCs effectivement trouvés (exemple `nbr_pdc = 2` et 4 PDCs avec le même station_id -> dans ce cas, la sortie contiendra `nbr_pdc = 0` et `nbr_pdc_unsure = 2`)
+* `nbre_pdc_unsure` : ce champ est ajouté lors du regroupement lorsque le `nbr_pdc` déclaré pour une station ne correspond pas aux nombres de PDCs effectivement trouvés (exemple `nbr_pdc = 2` et 4 PDCs avec le même station_id -> dans ce cas, la sortie contiendra `nbr_pdc = None` et `nbr_pdc_unsure = 2`)
 
 Voici les fichiers de sortie du retraitement :
 

--- a/group_opendata_by_station.py
+++ b/group_opendata_by_station.py
@@ -223,8 +223,8 @@ for station_id, station in station_list.items() :
         errors.append({"station_id" : station_id,
                        "source": station['attributes']['source_grouped'],
                        "error": "le nombre de point de charge de la station n'est pas cohérent avec la liste des points de charge fournie",
-                       "detail": "{} points de charge indiqués pour la station (nbre_pdc) mais {} points de charge listés".format(station['attributes']['nbre_pdc'], len(station['pdc_list']))})
-        station['attributes']['nbre_pdc'] = min(len(station['pdc_list']), int(station['attributes']['nbre_pdc']))
+                       "detail": "{} points de charge indiqués pour la station (nbre_pdc) mais {} points de charge listés".format(station['attributes']['nbre_pdc'], len(station['pdc_list']))})        
+        station['attributes']['nbre_pdc'] = None
 
     station['attributes']['nb_prises_grouped'] = len(station['pdc_list'])
 

--- a/group_opendata_by_station.py
+++ b/group_opendata_by_station.py
@@ -8,6 +8,7 @@ from collections import Counter
 
 station_list = {}
 station_attributes = [ 'nom_amenageur', 'siren_amenageur', 'contact_amenageur', 'nom_operateur', 'contact_operateur', 'telephone_operateur', 'nom_enseigne', 'id_station_itinerance', 'id_station_local', 'nom_station', 'implantation_station', 'code_insee_commune', 'nbre_pdc', 'station_deux_roues', 'raccordement', 'num_pdl', 'date_mise_en_service', 'observations', 'adresse_station' ]
+station_unsure_attributes = ['nbre_pdc_unsure']
 pdc_attributes = [ 'id_pdc_itinerance', 'id_pdc_local', 'puissance_nominale', 'prise_type_ef', 'prise_type_2', 'prise_type_combo_ccs', 'prise_type_chademo', 'prise_type_autre', 'gratuit', 'paiement_acte', 'paiement_cb', 'paiement_autre', 'tarification', 'condition_acces', 'reservation', 'accessibilite_pmr', 'restriction_gabarit', 'observations', 'date_maj', 'cable_t2_attache', 'datagouv_organization_or_owner', 'horaires' ]
 
 wrong_ortho = {}
@@ -117,6 +118,7 @@ with open('opendata_irve.csv') as csvfile:
                 elif row[key] in wrong_ortho.keys():
                     station_prop[key] = wrong_ortho[row[key]]
 
+            for key in station_unsure_attributes: station_prop[key] = ""
             station_prop['Xlongitude'] = float(row['consolidated_longitude'])
             station_prop['Ylatitude'] = float(row['consolidated_latitude'])
             phone = cleanPhoneNumber(row['telephone_operateur'])
@@ -224,6 +226,7 @@ for station_id, station in station_list.items() :
                        "source": station['attributes']['source_grouped'],
                        "error": "le nombre de point de charge de la station n'est pas cohérent avec la liste des points de charge fournie",
                        "detail": "{} points de charge indiqués pour la station (nbre_pdc) mais {} points de charge listés".format(station['attributes']['nbre_pdc'], len(station['pdc_list']))})        
+        station['attributes']['nbre_pdc_unsure'] = min(len(station['pdc_list']), int(station['attributes']['nbre_pdc']))
         station['attributes']['nbre_pdc'] = None
 
     station['attributes']['nb_prises_grouped'] = len(station['pdc_list'])

--- a/group_opendata_by_station.py
+++ b/group_opendata_by_station.py
@@ -229,8 +229,8 @@ for station_id, station in station_list.items() :
         errors.append({"station_id" : station_id,
                        "source": station['attributes']['source_grouped'],
                        "error": "le nombre de point de charge de la station n'est pas cohérent avec la liste des points de charge fournie",
-                       "detail": "{} points de charge indiqués pour la station (nbre_pdc) mais {} points de charge listés".format(station['attributes']['nbre_pdc'], len(station['pdc_list']))})        
-        station['attributes']['nbre_pdc'] = None
+                       "detail": "{} points de charge indiqués pour la station (nbre_pdc) mais {} points de charge listés".format(station['attributes']['nbre_pdc'], len(station['pdc_list']))})
+        station['attributes']['nbre_pdc'] = min(len(station['pdc_list']), int(station['attributes']['nbre_pdc']))
 
     station['attributes']['nb_prises_grouped'] = len(station['pdc_list'])
 


### PR DESCRIPTION
C'est à discuter. Je comprends qu'on préfère ne rien proposer plutôt qu'une valeur incorrecte.

Mon argument est de proposer une valeur par défaut conservatrice probablement juste plutôt que rien du tout.

Cependant l'idéal serait de fournir une liste de champs dont les valeurs sont "déduites" et de les signaler comme telles dans Osmose. (je peux m'occuper de ça avec les modifications correspondantes du côté Osmose)