### PR TITLE
Upgrade to latest Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup python version
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies && generate data for Osmose    


### PR DESCRIPTION
This repository uses old versions of Github Actions and theses actions uses a deprecated version of node js.
This PR upgrade actions to the latest version, there are no impact on workflow (maybe a little bit more fast)