### PR TITLE
remplacement "Compagnie Nationale du Rhône (CNR)"

### DIFF
--- a/fixes_networks.csv
+++ b/fixes_networks.csv
@@ -68,6 +68,7 @@
 "BYmyCAR BMW","BMW"
 "CC VITRY CHAMPAGNE ET DER","Communauté de communes Vitry, Champagne et Der"
 "CITROEN","Citroën"
+"Compagnie Nationale du Rhône (CNR)","Compagnie Nationale du Rhône"
 "concession HYUNDAI","Hyundai"
 "Concessionnaire Hyundai Sens","Hyundai"
 "Concessionnaire RENAULT","Renault"


### PR DESCRIPTION
fix #23