### PR TITLE
add property of puissance_nominale_grouped in opendata_stations.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,7 @@ Retraitement des données open data des points de recharge pour véhicules élec
 
 Le fichier open data utilisé est le fichier consolidé des bornes de rechage pour véhicules électriques, publié sur [datagouv](https://www.data.gouv.fr/fr/datasets/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques). Il s'agit d'un jeu de données qui regroupe l'ensemble des données produites par les différents acteurs territoriaux.
 
-## Installation
 
-### Créer le dossier de sortie
-
-Les scripts génèrent des fichiers dans le dossier `output/`. Créez ce dossier avant d'exécuter les scripts :
-
-```bash
-mkdir -p output
-```
-
-### Récupérer le jeu de données IRVE depuis data.gouv.fr
-
-Le fichier `opendata_irve.csv` doit être téléchargé depuis data.gouv.fr. 
-
-https://www.data.gouv.fr/fr/datasets/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques
-
-**URL de téléchargement direct actuelle** (peut changer) :
-```
-https://www.data.gouv.fr/fr/datasets/r/2729b192-40ab-4454-904d-735084dca3a3
-```
-
-Pour télécharger le fichier avec curl:
-
-```bash
-curl -L https://www.data.gouv.fr/fr/datasets/r/2729b192-40ab-4454-904d-735084dca3a3 -o opendata_irve.csv
-```
-
-**Note** : L'ID dans l'URL peut changer si le jeu de données est mis à jour. Vérifiez régulièrement la page du jeu de données pour obtenir l'URL la plus récente.
-
-Contrairement à ce que son nom laisse entendre, le jeu de données open data ne contient pas d'informations sur les bornes : il contient des points de recharge, ainsi que des informations sur les stations.
 
 ![définition des termes borne/station/point de charge](https://afirev.fr/wp-content/uploads/2019/08/Archi-station-borne-point-Fr-1024x610.jpg)
 *illustration issue de la [doc de l'AFIREV](https://afirev.fr/fr/definition-des-termes-de-la-mobilite-electrique/)*
@@ -64,3 +35,38 @@ Les données open data semblent être mises à jour tous les jours. Le présent 
 Les données consolidées ici sont utilisées par [l'analyse Osmose 8410](https://osmose.openstreetmap.fr/en/issues/open?item=8410).
 
 La correspondance entre les attributs est documentée sur le [wiki](https://wiki.openstreetmap.org/wiki/France/data.gouv.fr/Bornes_de_Recharge_pour_V%C3%A9hicules_%C3%89lectriques) et accessible dans le [code source d'Osmose](https://github.com/osm-fr/osmose-backend/blob/master/analysers/analyser_merge_charging_station_FR.py).
+
+## Installation
+
+### Créer le dossier de sortie
+
+Les scripts génèrent des fichiers dans le dossier `output/`. Créez ce dossier avant d'exécuter les scripts :
+
+```bash
+mkdir -p output
+```
+
+### Récupérer le jeu de données IRVE depuis data.gouv.fr
+
+Le fichier `opendata_irve.csv` doit être téléchargé depuis data.gouv.fr. 
+
+https://www.data.gouv.fr/fr/datasets/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques
+
+**URL de téléchargement direct actuelle** (peut changer) :
+```
+https://www.data.gouv.fr/fr/datasets/r/2729b192-40ab-4454-904d-735084dca3a3
+```
+
+Pour télécharger le fichier avec curl:
+
+```bash
+curl -L https://www.data.gouv.fr/fr/datasets/r/2729b192-40ab-4454-904d-735084dca3a3 -o opendata_irve.csv
+```
+
+L'ID dans l'URL peut changer si le jeu de données est mis à jour. Vérifiez régulièrement la page du jeu de données pour obtenir l'URL la plus récente.
+
+Contrairement à ce que son nom laisse entendre, le jeu de données open data ne contient pas d'informations sur les bornes : il contient des points de recharge, ainsi que des informations sur les stations.
+
+
+### Exécuter le retraitement
+`python group_opendata_by_station.py`

--- a/README.md
+++ b/README.md
@@ -4,6 +4,35 @@ Retraitement des données open data des points de recharge pour véhicules élec
 
 Le fichier open data utilisé est le fichier consolidé des bornes de rechage pour véhicules électriques, publié sur [datagouv](https://www.data.gouv.fr/fr/datasets/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques). Il s'agit d'un jeu de données qui regroupe l'ensemble des données produites par les différents acteurs territoriaux.
 
+## Installation
+
+### Créer le dossier de sortie
+
+Les scripts génèrent des fichiers dans le dossier `output/`. Créez ce dossier avant d'exécuter les scripts :
+
+```bash
+mkdir -p output
+```
+
+### Récupérer le jeu de données IRVE depuis data.gouv.fr
+
+Le fichier `opendata_irve.csv` doit être téléchargé depuis data.gouv.fr. 
+
+https://www.data.gouv.fr/fr/datasets/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques
+
+**URL de téléchargement direct actuelle** (peut changer) :
+```
+https://www.data.gouv.fr/fr/datasets/r/2729b192-40ab-4454-904d-735084dca3a3
+```
+
+Pour télécharger le fichier avec curl:
+
+```bash
+curl -L https://www.data.gouv.fr/fr/datasets/r/2729b192-40ab-4454-904d-735084dca3a3 -o opendata_irve.csv
+```
+
+**Note** : L'ID dans l'URL peut changer si le jeu de données est mis à jour. Vérifiez régulièrement la page du jeu de données pour obtenir l'URL la plus récente.
+
 Contrairement à ce que son nom laisse entendre, le jeu de données open data ne contient pas d'informations sur les bornes : il contient des points de recharge, ainsi que des informations sur les stations.
 
 ![définition des termes borne/station/point de charge](https://afirev.fr/wp-content/uploads/2019/08/Archi-station-borne-point-Fr-1024x610.jpg)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Retraitement des données open data des points de recharge pour véhicules élec
 
 Le fichier open data utilisé est le fichier consolidé des bornes de rechage pour véhicules électriques, publié sur [datagouv](https://www.data.gouv.fr/fr/datasets/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques). Il s'agit d'un jeu de données qui regroupe l'ensemble des données produites par les différents acteurs territoriaux.
 
-
+Contrairement à ce que son nom laisse entendre, le jeu de données open data ne contient pas d'informations sur les bornes : il contient des points de recharge, ainsi que des informations sur les stations.
 
 ![définition des termes borne/station/point de charge](https://afirev.fr/wp-content/uploads/2019/08/Archi-station-borne-point-Fr-1024x610.jpg)
 *illustration issue de la [doc de l'AFIREV](https://afirev.fr/fr/definition-des-termes-de-la-mobilite-electrique/)*

--- a/group_opendata_by_station.py
+++ b/group_opendata_by_station.py
@@ -254,14 +254,10 @@ for station_id, station in station_list.items() :
                 puissances.append(float(puissance_str))
             except ValueError:
                 pass
+    station['attributes']['puissance_nominale'] = elem['puissance_nominale']
+    station['attributes']['puissance_nominale_grouped'] = max(puissances) if puissances else None
     
-    if len(puissances) == 0:
-        station['attributes']['puissance_nominale_grouped'] = None
-    elif len(set(puissances)) == 1:
-        station['attributes']['puissance_nominale_grouped'] = puissances[0]
-    else:
-        # Si plusieurs puissances différentes, on prend la valeur la plus haute
-        station['attributes']['puissance_nominale_grouped'] = max(puissances)
+    if len(puissances) > 1:
         errors.append({"station_id" : station_id,
                        "source": station['attributes']['source_grouped'],
                        "error": "plusieurs puissances nominales différentes pour une même station",

--- a/group_opendata_by_station.py
+++ b/group_opendata_by_station.py
@@ -245,6 +245,28 @@ for station_id, station in station_list.items() :
     else :
         station['attributes']['accessibilite_pmr_grouped'] = list(accessibilite_pmr)[0]
 
+    # Regroupement de la puissance nominale
+    puissances = []
+    for elem in station['pdc_list']:
+        puissance_str = elem['puissance_nominale'].strip() if elem['puissance_nominale'] else ''
+        if puissance_str and puissance_str.lower() != 'null':
+            try:
+                puissances.append(float(puissance_str))
+            except ValueError:
+                pass
+    
+    if len(puissances) == 0:
+        station['attributes']['puissance_nominale_grouped'] = None
+    elif len(set(puissances)) == 1:
+        station['attributes']['puissance_nominale_grouped'] = puissances[0]
+    else:
+        # Si plusieurs puissances différentes, on prend la valeur la plus haute
+        station['attributes']['puissance_nominale_grouped'] = max(puissances)
+        errors.append({"station_id" : station_id,
+                       "source": station['attributes']['source_grouped'],
+                       "error": "plusieurs puissances nominales différentes pour une même station",
+                       "detail": puissances})
+
     if len(station['pdc_list']) != int(station['attributes']['nbre_pdc']):
         errors.append({"station_id" : station_id,
                        "source": station['attributes']['source_grouped'],


### PR DESCRIPTION
Add the property puissance_nominale_grouped in the csv. The aim is to have this property used in the Osmose IRVE analysis and LibreChargeMap.

The property's value taken is the higher value if the value is an enumeration as it is the interesting data for EV owners this column gives, we can build something more complicated but this is a first step to get this info available in the output.